### PR TITLE
#54 - use npm-run-all for sequental and parallel scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,16 +7,18 @@
     "cba-components": "./bin/cba-components.js"
   },
   "scripts": {
-    "test": "npm run build:puppeteer && npm run test:run",
-    "test:run": "concurrently -r -k -s=first \"http-server dist -s -p 3001\" \"mocha tests/puppeteer/mocha.js\"",
+    "build": "run-s clean webpack",
+    "build:puppeteer": "run-s clean \"webpack -- --puppeteer\"",
+    "build:smoke": "run-s clean \"webpack -- --smoke\"",
+    "build:smoke:watch": "run-s clean \"webpack -- --smoke --watch\"",
+    "clean": "rm -r dist || true",
+    "start": "run-p -r build:smoke:watch \"server -- 3000\"",
+    "server": "http-server dist -p",
+    "test": "npm-run-all -s build:puppeteer -p -r \"server -- 3001 -s\" test:run",
+    "test:run": "mocha tests/puppeteer/mocha.js",
     "test:eslint": "eslint \"src/**/*.js\" \"tests/**/*.js\"",
     "test:stylelint": "stylelint \"src/**/*.css\" \"tests/**/*.css\"",
-    "start": "concurrently -r -k \"npm run build:smoke:watch\" \"http-server dist -p 3000\"",
-    "build": "npm run clean && webpack --config webpack.config.js",
-    "build:puppeteer": "npm run clean && webpack --config webpack.config.js --puppeteer",
-    "build:smoke": "npm run clean && webpack --config webpack.config.js --smoke",
-    "build:smoke:watch": "npm run clean && webpack --config webpack.config.js --smoke --watch",
-    "clean": "rm -r dist || true"
+    "webpack": "webpack --config webpack.config.js"
   },
   "repository": {
     "type": "git",
@@ -34,10 +36,10 @@
     "raw-loader": "^4.0.0"
   },
   "devDependencies": {
-    "concurrently": "^6.1.0",
     "copy-webpack-plugin": "^5.1.1",
     "eslint": "^7.26.0",
     "mocha": "^7.0.1",
+    "npm-run-all": "^4.1.5",
     "puppeteer": "^8.0.0",
     "rimraf": "^3.0.2",
     "stylelint": "^13.13.1",


### PR DESCRIPTION
What is included:
- Replaces scripts running in parallel(i.e. using `&`) with `npm-p`.
- Replaced scripts that are running sequental(i.e. using `&&`) with `npm-s`.
- Reorganized scripts in alphabetical order.

Note:
- In windows single quote inside of the Json string doesn't seem to be supported, that's why `\"` is used instead.