### PR TITLE
#58 - Added eslint and stylelint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": "eslint:recommended",
+  "env": {
+    "es6": true,
+    "node": true,
+    "browser": true,
+    "mocha": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "brace-style": ["error", "allman"],
+    "eol-last": ["error", "always"],
+    "indent": ["error", 2],
+    "no-unused-vars":"error",
+    "no-trailing-spaces": "error",
+    "no-empty": "off",
+    "object-curly-spacing": ["error", "never"]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": "eslint:recommended",
+  "ignorePatterns": ["tests/smoke/res"],
   "env": {
     "es6": true,
     "node": true,
@@ -17,6 +18,7 @@
     "no-unused-vars":"error",
     "no-trailing-spaces": "error",
     "no-empty": "off",
-    "object-curly-spacing": ["error", "never"]
+    "object-curly-spacing": ["error", "never"],
+    "no-console": "error"
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,6 +2,7 @@
 "extends": "stylelint-config-recommended",
   "rules": {
     "block-closing-brace-newline-after": "always",
+    "block-opening-brace-newline-before": "always",
     "no-descending-specificity": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,7 @@
+{
+"extends": "stylelint-config-recommended",
+  "rules": {
+    "block-closing-brace-newline-after": "always",
+    "no-descending-specificity": null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "npm run build:puppeteer && npm run test:run",
     "test:run": "concurrently -r -k -s=first \"http-server dist -s -p 3001\" \"mocha tests/puppeteer/mocha.js\"",
+    "test:eslint": "eslint src/**/*.js tests/**/*.js",
     "start": "concurrently -r -k \"npm run build:smoke:watch\" \"http-server dist -p 3000\"",
     "build": "npm run clean && webpack --config webpack.config.js",
     "build:puppeteer": "npm run clean && webpack --config webpack.config.js --puppeteer",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "concurrently": "^6.1.0",
     "copy-webpack-plugin": "^5.1.1",
+    "eslint": "^7.26.0",
     "mocha": "^7.0.1",
     "puppeteer": "^8.0.0",
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "npm run build:puppeteer && npm run test:run",
     "test:run": "concurrently -r -k -s=first \"http-server dist -s -p 3001\" \"mocha tests/puppeteer/mocha.js\"",
     "test:eslint": "eslint \"src/**/*.js\" \"tests/**/*.js\"",
+    "test:stylelint": "stylelint \"src/**/*.css\" \"tests/**/*.css\"",
     "start": "concurrently -r -k \"npm run build:smoke:watch\" \"http-server dist -p 3000\"",
     "build": "npm run clean && webpack --config webpack.config.js",
     "build:puppeteer": "npm run clean && webpack --config webpack.config.js --puppeteer",
@@ -39,6 +40,8 @@
     "mocha": "^7.0.1",
     "puppeteer": "^8.0.0",
     "rimraf": "^3.0.2",
+    "stylelint": "^13.13.1",
+    "stylelint-config-recommended": "^5.0.0",
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10"
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run build:puppeteer && npm run test:run",
     "test:run": "concurrently -r -k -s=first \"http-server dist -s -p 3001\" \"mocha tests/puppeteer/mocha.js\"",
-    "test:eslint": "eslint src/**/*.js tests/**/*.js",
+    "test:eslint": "eslint \"src/**/*.js\" \"tests/**/*.js\"",
     "start": "concurrently -r -k \"npm run build:smoke:watch\" \"http-server dist -p 3000\"",
     "build": "npm run clean && webpack --config webpack.config.js",
     "build:puppeteer": "npm run clean && webpack --config webpack.config.js --puppeteer",

--- a/src/cba-button/cba-button.js
+++ b/src/cba-button/cba-button.js
@@ -1,10 +1,12 @@
 import shadowCSS from './shadow.css';
 
-class CbaButton extends HTMLElement {
-  constructor() {
+class CbaButton extends HTMLElement
+{
+  constructor()
+  {
     super();
 
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({mode: "open"});
     this.shadowRoot.innerHTML = `
       <style>
         ${shadowCSS}

--- a/src/cba-list-new/cba-list-new.js
+++ b/src/cba-list-new/cba-list-new.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import {html, render} from 'lit-html';
 import shadowCSS from './shadow.css';
 import ConstructableCSS from '../ConstructableCSS';

--- a/src/cba-list-new/cba-list-new.js
+++ b/src/cba-list-new/cba-list-new.js
@@ -4,8 +4,10 @@ import ConstructableCSS from '../ConstructableCSS';
 
 const constructableCSS = new ConstructableCSS(shadowCSS);
 
-class List extends HTMLElement {
-  constructor() {
+class List extends HTMLElement
+{
+  constructor()
+  {
     super();
     this.container = null;
     this.subheading = null;
@@ -17,7 +19,7 @@ class List extends HTMLElement {
     this._data = [
     ];
 
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({mode: "open"});
     this.shadowRoot.innerHTML = `
     <div id="container">
       <h2></h2>
@@ -42,7 +44,8 @@ class List extends HTMLElement {
     {
       if (!rowItem.id)
       {
-        while (this.getItem(`cba-list-id-${++this.idCount}`)) {}
+        while (this.getItem(`cba-list-id-${++this.idCount}`))
+        {}
         rowItem.id = `cba-list-id-${this.idCount}`;
       }
       if (rowItem.subItems)
@@ -69,7 +72,8 @@ class List extends HTMLElement {
     return JSON.parse(JSON.stringify(this._data));
   }
 
-  static get observedAttributes() {
+  static get observedAttributes()
+  {
     return ["sort", "heading", "subheading"];
   }
 
@@ -115,7 +119,7 @@ class List extends HTMLElement {
     this.tooltipLinkTextDefault = "Learn more";
     this.connected = true;
 
-    this.container.addEventListener("click", ({target}) => 
+    this.container.addEventListener("click", ({target}) =>
     {
       if (target.tagName === "BUTTON")
       {
@@ -249,7 +253,7 @@ class List extends HTMLElement {
 
   /**
    * Get textContent of the row element
-   * @param {string} id Row ID 
+   * @param {string} id Row ID
    * @return {string} row's textContent
    */
   _getRowContent(id)
@@ -263,7 +267,8 @@ class List extends HTMLElement {
    */
   saveEditables()
   {
-    while (this._findItem("editable", true)) {
+    while (this._findItem("editable", true))
+    {
       const item = this._findItem("editable", true);
       item.text = this._getRowContent(item.id);
       item.editable = false;
@@ -273,7 +278,7 @@ class List extends HTMLElement {
 
   /**
    * Make specific item editable
-   * @param {string} id Row ID  
+   * @param {string} id Row ID
    * @param {boolean} state editable state (true means editable)
    */
   setEditable(id, state)
@@ -469,7 +474,7 @@ class List extends HTMLElement {
    */
   getParentItem(rowId)
   {
-    const [index, parentIndex] = this.getIndex(rowId);
+    const [, parentIndex] = this.getIndex(rowId);
     if (parentIndex >= 0)
       return this.items[parentIndex];
     else
@@ -506,7 +511,8 @@ class List extends HTMLElement {
     }
     else if (tooltip.includes("$"))
     {
-      return tooltip.split("$").reduce((acc, prop, index, {length}) => {
+      return tooltip.split("$").reduce((acc, prop, index, {length}) =>
+      {
         if (index -1 === length)
           return acc[parseInt(prop, 10)] || "";
         else
@@ -575,13 +581,15 @@ class List extends HTMLElement {
         return row;
       }
     }
-    const createList = (item) => {
+    const createList = (item) =>
+    {
       const {id} = item;
       return html`<li data-id="${id}">
                       ${createRow(item)}
                   </li>`;
     }
-    const result = this._data.map((row) => {
+    const result = this._data.map((row) =>
+    {
       const {id, subItems, expanded} = row;
       if (subItems)
       {

--- a/src/cba-list-new/cba-list-new.js
+++ b/src/cba-list-new/cba-list-new.js
@@ -4,10 +4,8 @@ import ConstructableCSS from '../ConstructableCSS';
 
 const constructableCSS = new ConstructableCSS(shadowCSS);
 
-class List extends HTMLElement
-{
-  constructor()
-  {
+class List extends HTMLElement {
+  constructor() {
     super();
     this.container = null;
     this.subheading = null;
@@ -19,7 +17,7 @@ class List extends HTMLElement
     this._data = [
     ];
 
-    this.attachShadow({mode: "open"});
+    this.attachShadow({ mode: "open" });
     this.shadowRoot.innerHTML = `
     <div id="container">
       <h2></h2>
@@ -44,8 +42,7 @@ class List extends HTMLElement
     {
       if (!rowItem.id)
       {
-        while (this.getItem(`cba-list-id-${++this.idCount}`))
-        {}
+        while (this.getItem(`cba-list-id-${++this.idCount}`)) {}
         rowItem.id = `cba-list-id-${this.idCount}`;
       }
       if (rowItem.subItems)
@@ -72,8 +69,7 @@ class List extends HTMLElement
     return JSON.parse(JSON.stringify(this._data));
   }
 
-  static get observedAttributes()
-  {
+  static get observedAttributes() {
     return ["sort", "heading", "subheading"];
   }
 
@@ -119,7 +115,7 @@ class List extends HTMLElement
     this.tooltipLinkTextDefault = "Learn more";
     this.connected = true;
 
-    this.container.addEventListener("click", ({target}) =>
+    this.container.addEventListener("click", ({target}) => 
     {
       if (target.tagName === "BUTTON")
       {
@@ -253,7 +249,7 @@ class List extends HTMLElement
 
   /**
    * Get textContent of the row element
-   * @param {string} id Row ID
+   * @param {string} id Row ID 
    * @return {string} row's textContent
    */
   _getRowContent(id)
@@ -267,8 +263,7 @@ class List extends HTMLElement
    */
   saveEditables()
   {
-    while (this._findItem("editable", true))
-    {
+    while (this._findItem("editable", true)) {
       const item = this._findItem("editable", true);
       item.text = this._getRowContent(item.id);
       item.editable = false;
@@ -278,7 +273,7 @@ class List extends HTMLElement
 
   /**
    * Make specific item editable
-   * @param {string} id Row ID
+   * @param {string} id Row ID  
    * @param {boolean} state editable state (true means editable)
    */
   setEditable(id, state)
@@ -474,7 +469,7 @@ class List extends HTMLElement
    */
   getParentItem(rowId)
   {
-    const [, parentIndex] = this.getIndex(rowId);
+    const [index, parentIndex] = this.getIndex(rowId);
     if (parentIndex >= 0)
       return this.items[parentIndex];
     else
@@ -511,8 +506,7 @@ class List extends HTMLElement
     }
     else if (tooltip.includes("$"))
     {
-      return tooltip.split("$").reduce((acc, prop, index, {length}) =>
-      {
+      return tooltip.split("$").reduce((acc, prop, index, {length}) => {
         if (index -1 === length)
           return acc[parseInt(prop, 10)] || "";
         else
@@ -581,15 +575,13 @@ class List extends HTMLElement
         return row;
       }
     }
-    const createList = (item) =>
-    {
+    const createList = (item) => {
       const {id} = item;
       return html`<li data-id="${id}">
                       ${createRow(item)}
                   </li>`;
     }
-    const result = this._data.map((row) =>
-    {
+    const result = this._data.map((row) => {
       const {id, subItems, expanded} = row;
       if (subItems)
       {

--- a/src/cba-list-new/shadow.css
+++ b/src/cba-list-new/shadow.css
@@ -1,3 +1,4 @@
+/* stylelint-disable */
 :host
 {
   --hover-primary: #eaeaea;

--- a/src/cba-list/cba-list.js
+++ b/src/cba-list/cba-list.js
@@ -4,8 +4,10 @@ import ConstructableCSS from '../ConstructableCSS';
 
 const constructableCSS = new ConstructableCSS(shadowCSS);
 
-class List extends HTMLElement {
-  constructor() {
+class List extends HTMLElement
+{
+  constructor()
+  {
     super();
     this.container = null;
     this.subheading = null;
@@ -17,7 +19,7 @@ class List extends HTMLElement {
     this._data = [
     ];
 
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({mode: "open"});
     this.shadowRoot.innerHTML = `
     <div id="container">
       <h2></h2>
@@ -42,7 +44,8 @@ class List extends HTMLElement {
     {
       if (!rowItem.id)
       {
-        while (this.getItem(`cba-list-id-${++this.idCount}`)) {}
+        while (this.getItem(`cba-list-id-${++this.idCount}`))
+        {}
         rowItem.id = `cba-list-id-${this.idCount}`;
       }
       if (rowItem.subItems)
@@ -69,7 +72,8 @@ class List extends HTMLElement {
     return JSON.parse(JSON.stringify(this._data));
   }
 
-  static get observedAttributes() {
+  static get observedAttributes()
+  {
     return ["sort", "heading", "subheading"];
   }
 
@@ -115,7 +119,7 @@ class List extends HTMLElement {
     this.tooltipLinkTextDefault = "Learn more";
     this.connected = true;
 
-    this.container.addEventListener("click", ({target}) => 
+    this.container.addEventListener("click", ({target}) =>
     {
       if (target.tagName === "BUTTON")
       {
@@ -249,7 +253,7 @@ class List extends HTMLElement {
 
   /**
    * Get textContent of the row element
-   * @param {string} id Row ID 
+   * @param {string} id Row ID
    * @return {string} row's textContent
    */
   _getRowContent(id)
@@ -263,7 +267,8 @@ class List extends HTMLElement {
    */
   saveEditables()
   {
-    while (this._findItem("editable", true)) {
+    while (this._findItem("editable", true))
+    {
       const item = this._findItem("editable", true);
       item.text = this._getRowContent(item.id);
       item.editable = false;
@@ -273,7 +278,7 @@ class List extends HTMLElement {
 
   /**
    * Make specific item editable
-   * @param {string} id Row ID  
+   * @param {string} id Row ID
    * @param {boolean} state editable state (true means editable)
    */
   setEditable(id, state)
@@ -469,7 +474,7 @@ class List extends HTMLElement {
    */
   getParentItem(rowId)
   {
-    const [index, parentIndex] = this.getIndex(rowId);
+    const [, parentIndex] = this.getIndex(rowId);
     if (parentIndex >= 0)
       return this.items[parentIndex];
     else
@@ -506,7 +511,8 @@ class List extends HTMLElement {
     }
     else if (tooltip.includes("$"))
     {
-      return tooltip.split("$").reduce((acc, prop, index, {length}) => {
+      return tooltip.split("$").reduce((acc, prop, index, {length}) =>
+      {
         if (index -1 === length)
           return acc[parseInt(prop, 10)] || "";
         else
@@ -575,13 +581,15 @@ class List extends HTMLElement {
         return row;
       }
     }
-    const createList = (item) => {
+    const createList = (item) =>
+    {
       const {id} = item;
       return html`<li data-id="${id}">
                       ${createRow(item)}
                   </li>`;
     }
-    const result = this._data.map((row) => {
+    const result = this._data.map((row) =>
+    {
       const {id, subItems, expanded} = row;
       if (subItems)
       {

--- a/src/cba-list/shadow.css
+++ b/src/cba-list/shadow.css
@@ -211,7 +211,6 @@ li > button
   position: absolute;
   width: 18px;
   height: calc(1em + 4px);
-  position: absolute;
   cursor: pointer;
   border: 0px;
 }
@@ -257,6 +256,8 @@ li > button.collapsed
   opacity: 1;
   transition: visibility 0.3s, opacity 0.3s linear;
   font-size: 1em;
+  top: var(--tooltip-adjust-y);
+  left: var(--tooltip-adjust-x);
   z-index: 21;
 }
 
@@ -292,9 +293,4 @@ li > button.collapsed
 
 #tooltip a {
   float: right;
-}
-
-#tooltip {
-  top: var(--tooltip-adjust-y);
-  left: var(--tooltip-adjust-x);
 }

--- a/src/cba-list/shadow.css
+++ b/src/cba-list/shadow.css
@@ -261,7 +261,8 @@ li > button.collapsed
   z-index: 21;
 }
 
-#tooltip::before {
+#tooltip::before
+{
   content: "";
   font-size: 0;
   line-height: 0;
@@ -283,14 +284,17 @@ li > button.collapsed
   visibility: hidden;
 }
 
-#tooltip h4 {
+#tooltip h4
+{
   margin: 0;
 }
 
-#tooltip p {
+#tooltip p
+{
   margin: 0;
 }
 
-#tooltip a {
+#tooltip a
+{
   float: right;
 }

--- a/src/cba-table/cba-table.js
+++ b/src/cba-table/cba-table.js
@@ -5,8 +5,10 @@ import ConstructableCSS from '../ConstructableCSS';
 
 const constructableCSS = new ConstructableCSS(shadowCSS);
 
-class Table extends HTMLElement {
-  constructor() {
+class Table extends HTMLElement
+{
+  constructor()
+  {
     super();
     this._data = [];
     this.columns = [];
@@ -20,7 +22,7 @@ class Table extends HTMLElement {
     this.reordering = false;
     this.rowLastHoverId = null;
 
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({mode: "open"});
     this.shadowRoot.innerHTML = `
     <div id="container">
       <h2></h2>
@@ -42,11 +44,12 @@ class Table extends HTMLElement {
    */
   set items(rowItems)
   {
-    this._data = rowItems.map((rowItem) => 
+    this._data = rowItems.map((rowItem) =>
     {
       if (!rowItem.id)
       {
-        while (this.getItem(`cba-table-id-${++this.idCount}`)) {}
+        while (this.getItem(`cba-table-id-${++this.idCount}`))
+        {}
         rowItem.id = `cba-table-id-${this.idCount}`;
       }
       return rowItem;
@@ -63,7 +66,8 @@ class Table extends HTMLElement {
     return JSON.parse(JSON.stringify(this._data));
   }
 
-  static get observedAttributes() {
+  static get observedAttributes()
+  {
     return ["caption"];
   }
 
@@ -108,9 +112,9 @@ class Table extends HTMLElement {
     // offset of the sticky header
     const offset = this.tableElem.offsetTop + "px";
     this.tableElem.style.setProperty("--head-columns-offset", offset);
-    
+
     this._renderBody();
-    this.tableBodyElem.addEventListener("click", ({target}) => 
+    this.tableBodyElem.addEventListener("click", ({target}) =>
     {
       const row = target.closest("tr");
       if (row)
@@ -128,7 +132,7 @@ class Table extends HTMLElement {
       }
     });
 
-    this.tableBodyElem.addEventListener("mouseout", ({target}) => 
+    this.tableBodyElem.addEventListener("mouseout", ({target}) =>
     {
       const row = target.closest("tr");
       if (row && row.dataset.id === this.rowLastHoverId)
@@ -168,7 +172,7 @@ class Table extends HTMLElement {
         if (e.clientY < 50)
         {
           this.containerElem.scroll({
-            top: this.containerElem.scrollTop - 100, 
+            top: this.containerElem.scrollTop - 100,
             behavior: "smooth"
           });
         }
@@ -229,7 +233,7 @@ class Table extends HTMLElement {
         {
           const dropIndex = this._getItemIndex(dropRowId);
           const itemBefore = dropAfter ? this._data[dropIndex] :
-                                         this._data[dropIndex - 1];
+            this._data[dropIndex - 1];
 
           if (dropIndex == 0 && !dropAfter)
             this.addFirstRow(item);
@@ -302,7 +306,7 @@ class Table extends HTMLElement {
       {
         this.reordering = true;
         const row = e.target.closest("[data-id]");
-        
+
         // Hiding dragged row
         window.requestAnimationFrame(()=>
         {
@@ -342,7 +346,7 @@ class Table extends HTMLElement {
 
   /**
    * Unshifts a new row to items
-   * @param {object} data  new row data 
+   * @param {object} data  new row data
    */
   addFirstRow(data)
   {
@@ -412,7 +416,7 @@ class Table extends HTMLElement {
     const selectedIndex = this._getItemIndex(this.getSelectedItem().id);
     if (selectedIndex == -1)
       return;
-    
+
     const itemToSelect = this._data[selectedIndex + 1] || this._data[0];
     this.selectRow(itemToSelect.id);
   }
@@ -425,7 +429,7 @@ class Table extends HTMLElement {
     const selectedIndex = this._getItemIndex(this.getSelectedItem().id);
     if (selectedIndex == -1)
       return;
-    
+
     const itemToSelect = this._data[selectedIndex - 1] ||
                          this._data[this._data.length - 1];
     this.selectRow(itemToSelect.id);
@@ -481,7 +485,8 @@ class Table extends HTMLElement {
     }
     else if (colText.includes("$"))
     {
-      return colText.split("$").reduce((acc, prop, index, {length}) => {
+      return colText.split("$").reduce((acc, prop, index, {length}) =>
+      {
         if (index -1 === length)
           return acc[parseInt(prop, 10)] || "";
         else
@@ -496,10 +501,12 @@ class Table extends HTMLElement {
    */
   _renderBody()
   {
-    const createRow = (rowData) => {
+    const createRow = (rowData) =>
+    {
       const {id, selected} = rowData;
       const selectedClass = selected ? "highlight" : undefined;
-      return html`<tr data-id="${id}" class=${ifDefined(selectedClass)} draggable="${ifDefined(this.reorder)}" tabindex=${selected ? 0 : -1}>${this.columns.map((name) => {
+      return html`<tr data-id="${id}" class=${ifDefined(selectedClass)} draggable="${ifDefined(this.reorder)}" tabindex=${selected ? 0 : -1}>${this.columns.map((name) =>
+      {
         const text = this._getText(rowData, name);
         return html`<td data-id="${name}" title="${text}">${text}</td>`;
       })}</tr>`;
@@ -513,8 +520,8 @@ class Table extends HTMLElement {
                                <span class="resize"></span>`;
     const columns = html`<tr data-action="select"
                              data-key-down="next-sibling"
-                             data-key-up="previouse-sibling">${this.columns.map((column) => 
-                    html`<th data-id="${column}">${columnContent}</th>`)}</tr>`;
+                             data-key-up="previouse-sibling">${this.columns.map((column) =>
+    html`<th data-id="${column}">${columnContent}</th>`)}</tr>`;
     render(columns, this.tableHeadElem);
   }
 
@@ -529,8 +536,10 @@ class Table extends HTMLElement {
  * new custom element which reflects the status of those elements in the shadow
  * DOM.
  */
-class Column extends HTMLElement {
-  constructor() {
+class Column extends HTMLElement
+{
+  constructor()
+  {
     super();
     this.table = null;
     this.tableElem = null;
@@ -543,7 +552,8 @@ class Column extends HTMLElement {
     this.startWidth = 0;
   }
 
-  static get observedAttributes() {
+  static get observedAttributes()
+  {
     return ["text", "width"];
   }
 
@@ -589,9 +599,9 @@ class Column extends HTMLElement {
     // Fetch content change
     const observer = new MutationObserver(this._render.bind(this));
     const config = {characterData: true,
-                    attributes: false,
-                    childList: false,
-                    subtree: true };
+      attributes: false,
+      childList: false,
+      subtree: true};
     observer.observe(this, config);
 
     this._render();

--- a/src/cba-table/shadow.css
+++ b/src/cba-table/shadow.css
@@ -177,7 +177,8 @@ thead tr:after
                               var(--column-secondary) 100%);
 }
 
-#container.dragenter tbody:after {
+#container.dragenter tbody:after
+{
   position: absolute;
   content: "";
   border: 1px solid var(--color-border);
@@ -186,7 +187,8 @@ thead tr:after
   display: block;
 }
 
-#container.dragenter tbody:empty:after {
+#container.dragenter tbody:empty:after
+{
   background: linear-gradient(var(--hover-primary) 0%,
                               var(--hover-primary) 50%,
                               var(--hover-secondary) 50%,

--- a/src/cba-table/shadow.css
+++ b/src/cba-table/shadow.css
@@ -28,6 +28,8 @@ h2
   font-size: 11px;
   padding: 3px;
   background: linear-gradient(#dedede, #cecece);
+  top: 0px;
+  position: sticky;
   z-index: 20;
 }
 table
@@ -90,12 +92,6 @@ thead
 
 thead tr
 {
-  position: sticky;
-}
-
-h2
-{
-  top: 0px;
   position: sticky;
 }
 

--- a/src/cba-tabs/cba-tabs.js
+++ b/src/cba-tabs/cba-tabs.js
@@ -1,5 +1,7 @@
-class CbaTabs extends HTMLElement {
-  constructor() {
+class CbaTabs extends HTMLElement
+{
+  constructor()
+  {
     super();
     this.tabs = [];
     this.selectedTab = null;
@@ -61,8 +63,10 @@ class CbaTabs extends HTMLElement {
   }
 }
 
-class CbaTab extends HTMLElement {
-  constructor() {
+class CbaTab extends HTMLElement
+{
+  constructor()
+  {
     super();
     this.panel = null;
     this.tabs = null;
@@ -99,8 +103,10 @@ class CbaTab extends HTMLElement {
   }
 }
 
-class CbaPanel extends HTMLElement {
-  constructor() {
+class CbaPanel extends HTMLElement
+{
+  constructor()
+  {
     super();
   }
 

--- a/src/cba-tooltip/cba-tooltip.js
+++ b/src/cba-tooltip/cba-tooltip.js
@@ -4,11 +4,13 @@ import ConstructableCSS from '../ConstructableCSS';
 
 const constructableCSS = new ConstructableCSS(shadowCSS);
 
-class List extends HTMLElement {
-  constructor() {
+class List extends HTMLElement
+{
+  constructor()
+  {
     super();
 
-    this.attachShadow({ mode: "open" });
+    this.attachShadow({mode: "open"});
     this.shadowRoot.innerHTML = `
     <slot></slot>
     <div id="tooltip" role="tooltip"></div>
@@ -31,7 +33,8 @@ class List extends HTMLElement {
     this._render();
   }
 
-  static get observedAttributes() {
+  static get observedAttributes()
+  {
     return ["arrow"];
   }
 
@@ -53,7 +56,8 @@ class List extends HTMLElement {
     }
   }
 
-  setData(data) {
+  setData(data)
+  {
     const {text, link, linkText, heading, action, actionText} = data;
     if (text)
       this.text = text;
@@ -69,7 +73,8 @@ class List extends HTMLElement {
       this.actionText = actionText;
   }
 
-  _setAxis() {
+  _setAxis()
+  {
     this.arrow = this.getAttribute("arrow") === "y" ? "y" : "x";
     this.tooltipElem.dataset.arrow = this.arrow;
   }
@@ -91,15 +96,18 @@ class List extends HTMLElement {
     this.tooltipElem.dataset.tooltip = `${placementX}-${placementY}`;
   }
 
-  disable() {
+  disable()
+  {
     this.setAttribute("disabled", true);
   }
 
-  enable() {
+  enable()
+  {
     this.removeAttribute("disabled");
   }
 
-  isDisabled() {
+  isDisabled()
+  {
     return this.getAttribute("disabled");
   }
 

--- a/src/cba-tooltip/shadow.css
+++ b/src/cba-tooltip/shadow.css
@@ -31,7 +31,8 @@
   --tooltip-adjust-y: calc(var(--tooltip-offset-y) + var(--content-height) - var(--arrow-adjust-y) + 2px);
 }
 
-#tooltip::before {
+#tooltip::before
+{
   content: "";
   font-size: 0;
   line-height: 0;
@@ -43,7 +44,8 @@
   transform: rotate(45deg);
 }
 
-#tooltip {
+#tooltip
+{
   font-size: 1em;
   border: var(--border-size) solid var(--color-border);
   background-color: var(--color-background);
@@ -65,120 +67,143 @@
   visibility: hidden;
 }
 
-#tooltip h4 {
+#tooltip h4
+{
   margin: 0;
 }
 
-#tooltip p {
+#tooltip p
+{
   margin: 0;
 }
 
-#tooltip #links {
+#tooltip #links
+{
   float: right;
 }
 
-#tooltip[data-tooltip="right-bottom"] {
+#tooltip[data-tooltip="right-bottom"]
+{
   left: var(--tooltip-adjust-x);
   top: var(--tooltip-adjust-y);
 }
 
-#tooltip[data-tooltip="right-bottom"]::before {
+#tooltip[data-tooltip="right-bottom"]::before
+{
   top: var(--arrow-adjust-y);
   left: var(--arrow-adjust-x);
 }
 
-#tooltip[data-tooltip="right-bottom"][data-arrow="y"] {
+#tooltip[data-tooltip="right-bottom"][data-arrow="y"]
+{
   left: var(--tooltip-adjust-x);
   top: var(--tooltip-adjust-y);
 }
 
-#tooltip[data-tooltip="right-bottom"][data-arrow="y"]::before {
+#tooltip[data-tooltip="right-bottom"][data-arrow="y"]::before
+{
   top: var(--arrow-adjust-y);
   left: var(--arrow-adjust-x);
 }
 
-#tooltip[data-tooltip="left-bottom"] {
+#tooltip[data-tooltip="left-bottom"]
+{
   right: var(--tooltip-adjust-x);
   top: var(--tooltip-adjust-y);
 }
 
-#tooltip[data-tooltip="left-bottom"]::before {
+#tooltip[data-tooltip="left-bottom"]::before
+{
   top: var(--arrow-adjust-y);
   right: var(--arrow-adjust-x);
 }
 
-#tooltip[data-tooltip="left-bottom"][data-arrow="y"] {
+#tooltip[data-tooltip="left-bottom"][data-arrow="y"]
+{
   right: var(--tooltip-adjust-x);
   top: var(--tooltip-adjust-y);
 }
 
-#tooltip[data-tooltip="left-bottom"][data-arrow="y"]::before {
+#tooltip[data-tooltip="left-bottom"][data-arrow="y"]::before
+{
   top: var(--arrow-adjust-y);
   right: var(--arrow-adjust-x);
 }
 
-#tooltip[data-tooltip="right-top"] {
+#tooltip[data-tooltip="right-top"]
+{
   left: var(--tooltip-adjust-x);
   bottom: var(--tooltip-adjust-y);
 }
 
-#tooltip[data-tooltip="right-top"]::before {
+#tooltip[data-tooltip="right-top"]::before
+{
   left: var(--arrow-adjust-x);
   bottom: var(--arrow-adjust-y);
 }
 
-#tooltip[data-tooltip="right-top"][data-arrow="y"] {
+#tooltip[data-tooltip="right-top"][data-arrow="y"]
+{
   left: var(--tooltip-adjust-x);
   bottom: var(--tooltip-adjust-y);
 }
 
-#tooltip[data-tooltip="right-top"][data-arrow="y"]::before {
+#tooltip[data-tooltip="right-top"][data-arrow="y"]::before
+{
   bottom: var(--arrow-adjust-y);
   right: var(--arrow-adjust-x);
 }
 
-#tooltip[data-tooltip="left-top"] {
+#tooltip[data-tooltip="left-top"]
+{
   right: var(--tooltip-adjust-x);
   bottom: var(--tooltip-adjust-y);
 }
 
-#tooltip[data-tooltip="left-top"]::before {
+#tooltip[data-tooltip="left-top"]::before
+{
   right: var(--arrow-adjust-x);
   bottom: var(--arrow-adjust-y);
 }
 
-#tooltip[data-tooltip="left-top"][data-arrow="y"] {
+#tooltip[data-tooltip="left-top"][data-arrow="y"]
+{
   right: var(--tooltip-adjust-x);
   bottom: var(--tooltip-adjust-y);
 }
 
 /* Arrow borders */
 
-#tooltip[data-tooltip="left-top"][data-arrow="y"]::before {
+#tooltip[data-tooltip="left-top"][data-arrow="y"]::before
+{
   bottom: var(--arrow-adjust-y);
   right: var(--arrow-adjust-x);
 }
 
 #tooltip[data-tooltip="left-top"][data-arrow="x"]::before,
-#tooltip[data-tooltip="left-bottom"][data-arrow="x"]::before {
+#tooltip[data-tooltip="left-bottom"][data-arrow="x"]::before
+{
   border-bottom-color: transparent;
   border-left-color: transparent;
 }
 
 #tooltip[data-tooltip="right-top"][data-arrow="x"]::before,
-#tooltip[data-tooltip="right-bottom"][data-arrow="x"]::before {
+#tooltip[data-tooltip="right-bottom"][data-arrow="x"]::before
+{
   border-top-color: transparent;
   border-right-color: transparent;
 }
 
 #tooltip[data-tooltip="left-top"][data-arrow="y"]::before,
-#tooltip[data-tooltip="right-top"][data-arrow="y"]::before {
+#tooltip[data-tooltip="right-top"][data-arrow="y"]::before
+{
   border-top-color: transparent;
   border-left-color: transparent;
 }
 
 #tooltip[data-tooltip="left-bottom"][data-arrow="y"]::before,
-#tooltip[data-tooltip="right-bottom"][data-arrow="y"]::before {
+#tooltip[data-tooltip="right-bottom"][data-arrow="y"]::before
+{
   border-right-color: transparent;
   border-bottom-color: transparent;
 }

--- a/src/cba-tooltip/shadow.css
+++ b/src/cba-tooltip/shadow.css
@@ -44,6 +44,7 @@
 }
 
 #tooltip {
+  font-size: 1em;
   border: var(--border-size) solid var(--color-border);
   background-color: var(--color-background);
   color: var(--color-foreground);
@@ -62,10 +63,6 @@
 {
   opacity: 0;
   visibility: hidden;
-}
-
-#tooltip {
-  font-size: 1em;
 }
 
 #tooltip h4 {

--- a/tests/puppeteer/classes/CbaList.js
+++ b/tests/puppeteer/classes/CbaList.js
@@ -1,4 +1,3 @@
-const {page} = require("../main");
 const {Common} = require("./Common");
 
 const cbaListMethods = ["addRow", "updateRow", "deleteRow", "getItem",
@@ -138,10 +137,12 @@ class CbaList extends Common
     const item = await this.getItem(id);
     return item.expanded === true;
   }
-};
+}
 
-cbaListMethods.forEach((methodName) => {
-  CbaList.prototype[methodName] = async function() {
+cbaListMethods.forEach((methodName) =>
+{
+  CbaList.prototype[methodName] = async function()
+  {
     return await this._executeMethod(methodName, ...arguments)
   };
 });

--- a/tests/puppeteer/classes/CbaListNew.js
+++ b/tests/puppeteer/classes/CbaListNew.js
@@ -1,4 +1,3 @@
-const {page} = require("../main");
 const {Common} = require("./Common");
 
 const cbaListMethods = ["addRow", "updateRow", "deleteRow", "getItem",
@@ -138,10 +137,12 @@ class CbaList extends Common
     const item = await this.getItem(id);
     return item.expanded === true;
   }
-};
+}
 
-cbaListMethods.forEach((methodName) => {
-  CbaList.prototype[methodName] = async function() {
+cbaListMethods.forEach((methodName) =>
+{
+  CbaList.prototype[methodName] = async function()
+  {
     return await this._executeMethod(methodName, ...arguments)
   };
 });

--- a/tests/puppeteer/classes/CbaTable.js
+++ b/tests/puppeteer/classes/CbaTable.js
@@ -1,8 +1,7 @@
-const {page} = require("../main");
 const {Common} = require("./Common");
 
 const cbaTableMethods = ["addRow", "updateRow", "deleteRow", "getItem",
-                         "selectRow", "selectNextRow", "selectPreviousRow"];
+  "selectRow", "selectNextRow", "selectPreviousRow"];
 
 class CbaTable extends Common
 {
@@ -46,12 +45,13 @@ class CbaTable extends Common
     if (!rowHandle)
       return false;
 
-    return rowHandle.evaluate((row) => 
+    return rowHandle.evaluate((row) =>
     {
       const cells = row.querySelectorAll("td");
       if (!cells.length)
         return false;
-      return [...cells].reduce((acc, cell) => {
+      return [...cells].reduce((acc, cell) =>
+      {
         acc.push(cell.textContent);
         return acc;
       }, []);
@@ -81,7 +81,8 @@ class CbaTable extends Common
   async getRowBoundingClientRect(id)
   {
     const handle = await this.getRowHandle(id);
-    return handle.evaluate((cbaTableRow) => {
+    return handle.evaluate((cbaTableRow) =>
+    {
       const {top, left, bottom, right} = cbaTableRow.getBoundingClientRect();
       return {top, left, bottom, right};
     });
@@ -96,8 +97,10 @@ class CbaTable extends Common
   {
     const rowHandle = await this.getRowHandle(rowId);
     const cbaTableHandle = await this._getHandle();
-    return cbaTableHandle.evaluate((cbaTable, row, dispatch, expect) => {
-      return new Promise((resolve) => {
+    return cbaTableHandle.evaluate((cbaTable, row, dispatch, expect) =>
+    {
+      return new Promise((resolve) =>
+      {
         cbaTable.addEventListener(expect, ({detail}) =>
         {
           return resolve(detail);
@@ -112,10 +115,12 @@ class CbaTable extends Common
     const handle = await this.getRowHandle(id);
     return handle.hover();
   }
-};
+}
 
-cbaTableMethods.forEach((methodName) => {
-  CbaTable.prototype[methodName] = async function() {
+cbaTableMethods.forEach((methodName) =>
+{
+  CbaTable.prototype[methodName] = async function()
+  {
     return await this._executeMethod(methodName, ...arguments)
   };
 });

--- a/tests/puppeteer/classes/CbaTooltip.js
+++ b/tests/puppeteer/classes/CbaTooltip.js
@@ -1,4 +1,3 @@
-const {page} = require("../main");
 const {Common} = require("./Common");
 
 const cbaTooltipMethods = ["setData", "disable", "enable", "isDisabled"];
@@ -58,10 +57,12 @@ class CbaTooltip extends Common
     const handle = await tooltipHandle.$("a:nth-of-type(2)");
     return handle.click();
   }
-};
+}
 
-cbaTooltipMethods.forEach((methodName) => {
-  CbaTooltip.prototype[methodName] = async function() {
+cbaTooltipMethods.forEach((methodName) =>
+{
+  CbaTooltip.prototype[methodName] = async function()
+  {
     return await this._executeMethod(methodName, ...arguments);
   };
 });

--- a/tests/puppeteer/classes/Common.js
+++ b/tests/puppeteer/classes/Common.js
@@ -26,8 +26,10 @@ class Common
   }
   async _triggerEvent(handle, eventName, eventData = {})
   {
-    return handle.evaluate((elem, eventName, eventData) => {
-      return new Promise((resolve) => {
+    return handle.evaluate((elem, eventName, eventData) =>
+    {
+      return new Promise((resolve) =>
+      {
         elem.addEventListener(eventName, (e) =>
         {
           resolve(e);
@@ -36,9 +38,9 @@ class Common
         const event = new DragEvent(eventName, Object.assign(data, eventData));
         elem.dispatchEvent(event);
       });
-      
+
     }, eventName, eventData);
   }
-};
+}
 
 module.exports = {Common};

--- a/tests/puppeteer/main.js
+++ b/tests/puppeteer/main.js
@@ -17,7 +17,8 @@ function run()
 {
   for (const {path, name} of tests)
   {
-    describe(name, () => {
+    describe(name, () =>
+    {
       const {pageSetup} = require(`./tests/${path}`);
       before(async () =>
       {

--- a/tests/puppeteer/tests/cba-list-new.js
+++ b/tests/puppeteer/tests/cba-list-new.js
@@ -231,9 +231,4 @@ async function prepopulatedItems(expanded)
   return items;
 }
 
-function wait(milliseconds = 200)
-{
-  page().waitFor(milliseconds);
-}
-
 module.exports = {pageSetup};

--- a/tests/puppeteer/tests/cba-list-sorting.js
+++ b/tests/puppeteer/tests/cba-list-sorting.js
@@ -1,12 +1,5 @@
 const assert = require("assert");
 const equal = assert.strictEqual;
-const deepEqual = assert.deepStrictEqual;
-const notDeepEqual = assert.notDeepStrictEqual;
-const ok = assert.ok;
-const notOk = (value) => ok(!value);
-
-// page is only accessible in it() functions, as those are called after before()
-const {page} = require("../main");
 
 const pageSetup = {
   body: `<cba-list sort="asc"></cba-list>`,
@@ -31,7 +24,7 @@ it("sort='asc' should sort items ascendingly", async() =>
 
 it("sort='desc' should sort items descendingly", async() =>
 {
-  
+
   await cbaList.setSort("desc");
   await prepopulatedItems();
   equal(await cbaList.getDomRowIndexText(0), "List3");

--- a/tests/puppeteer/tests/cba-list-tooltip.js
+++ b/tests/puppeteer/tests/cba-list-tooltip.js
@@ -1,12 +1,7 @@
 const assert = require("assert");
 const equal = assert.strictEqual;
-const deepEqual = assert.deepStrictEqual;
-const notDeepEqual = assert.notDeepStrictEqual;
 const ok = assert.ok;
 const notOk = (value) => ok(!value);
-
-// page is only accessible in it() functions, as those are called after before()
-const {page} = require("../main");
 
 const pageSetup = {
   body: `<cba-list heading="Heading text" subHeading="Subheading text" tooltip-text="tooltip.text" tooltip-link="tooltip.link" tooltip-link-text="tooltip.linkText"></cba-list>`,
@@ -74,10 +69,5 @@ it("cba-list rows with matching data of tooltip-text and tooltip-link attribute 
   await cbaList.hoverRow(tooltipRowId);
   equal(await cbaList.getTooltipAttribute("class"), "");
 });
-
-function wait(milliseconds = 200)
-{
-  page().waitFor(milliseconds);
-}
 
 module.exports = {pageSetup};

--- a/tests/puppeteer/tests/cba-list.js
+++ b/tests/puppeteer/tests/cba-list.js
@@ -231,9 +231,4 @@ async function prepopulatedItems(expanded)
   return items;
 }
 
-function wait(milliseconds = 200)
-{
-  page().waitFor(milliseconds);
-}
-
 module.exports = {pageSetup};

--- a/tests/puppeteer/tests/cba-table.js
+++ b/tests/puppeteer/tests/cba-table.js
@@ -109,7 +109,7 @@ it("Hovering table row dispatches rowmouseover event with the rowId in details",
 {
   const items = await prepopulatedItems();
   const detail = await cbaTable.dispatchExpectRowEvent(items[0].id, "mouseover",
-                                                       "rowmouseover");
+    "rowmouseover");
   equal(detail.rowId, items[0].id);
 });
 
@@ -117,7 +117,7 @@ it("Hovering out table row dispatches rowmouseout event with the rowId in detail
 {
   const items = await prepopulatedItems();
   const detail = await cbaTable.dispatchExpectRowEvent(items[0].id, "mouseout",
-                                                       "rowmouseout");
+    "rowmouseout");
   equal(detail.rowId, items[0].id);
 });
 
@@ -162,7 +162,8 @@ async function itemIsHighlighted(item)
 async function prepopulatedItems()
 {
   const items = [];
-  for (let index = 1; index <= 3; index++) {
+  for (let index = 1; index <= 3; index++)
+  {
     const item = {
       id: "row" + index,
       data: "Info",

--- a/tests/puppeteer/tests/cba-tooltip.js
+++ b/tests/puppeteer/tests/cba-tooltip.js
@@ -1,9 +1,6 @@
 const assert = require("assert");
 const equal = assert.strictEqual;
-const deepEqual = assert.deepStrictEqual;
-const notDeepEqual = assert.notDeepStrictEqual;
 const ok = assert.ok;
-const notOk = (value) => ok(!value);
 
 // page is only accessible in it() functions, as those are called after before()
 const {page} = require("../main");
@@ -53,7 +50,8 @@ it("heading, text, link, link-text attributes populate the tooltip accoridngly",
   const attributesObj = {heading, text, link, "link-text": linkText};
 
   let attributes = "";
-  for (const attribute in attributesObj) {
+  for (const attribute in attributesObj)
+  {
     attributes += ` ${attribute}="${attributesObj[attribute]}"`;
   }
 
@@ -74,7 +72,7 @@ it("Passing object with heading, text, link, linkText, action, actionText proper
   const linkText = "Text link text";
   const actionText = "Add class";
   const handle = await cbaTooltip._getHandle();
-  await handle.evaluate((tooltip, heading, text, link, linkText, actionText) => 
+  await handle.evaluate((tooltip, heading, text, link, linkText, actionText) =>
   {
     const action = () => document.body.classList.add("action");
     tooltip.setData({heading, text, link, linkText, action, actionText});
@@ -97,9 +95,10 @@ it("arrow attribute with 'x' and 'y' values updates tooltip data-arrow attribute
   equal(await cbaTooltip.getTooltipDataArrow(), "y");
 });
 
-async function moveTooltip(vertical, horizontal) {
+async function moveTooltip(vertical, horizontal)
+{
   const handle = await cbaTooltip._getHandle();
-  return handle.evaluate((tooltip, vertical, horizontal) => 
+  return handle.evaluate((tooltip, vertical, horizontal) =>
   {
     tooltip.style.position = "absolute";
     tooltip.style.top = "auto";
@@ -117,11 +116,13 @@ async function moveTooltip(vertical, horizontal) {
   }, vertical, horizontal);
 }
 
-async function setPageBody(body) {
+async function setPageBody(body)
+{
   return page().evaluate((bodyHTML) => document.body.innerHTML = bodyHTML, body);
 }
 
-async function hoverTooltip() {
+async function hoverTooltip()
+{
   const handle = await cbaTooltip._getHandle();
   return handle.hover();
 }

--- a/tests/puppeteer/tests/drag-drop.js
+++ b/tests/puppeteer/tests/drag-drop.js
@@ -1,7 +1,6 @@
 const assert = require("assert");
 const equal = assert.strictEqual;
 const deepEqual = assert.deepStrictEqual;
-const notDeepEqual = assert.notDeepStrictEqual;
 const ok = assert.ok;
 const notOk = (value) => ok(!value);
 
@@ -130,7 +129,8 @@ it("Dragging cba-list item and dropping to cba-table row bottom adds item below 
 async function populateCbaList()
 {
   const items = [];
-  for (let index = 1; index <= 3; index++) {
+  for (let index = 1; index <= 3; index++)
+  {
     const item = {
       id: "row" + index,
       data: {
@@ -153,7 +153,8 @@ async function populateCbaList()
 async function populateCbaTable()
 {
   const items = [];
-  for (let index = 1; index <= 5; index++) {
+  for (let index = 1; index <= 5; index++)
+  {
     const item = {
       id: `row${index}`,
       data: "Info",
@@ -175,8 +176,10 @@ async function triggerDrop(id, data)
 {
   const handle = await cbaTable.getRowHandle(id);
   const table = await cbaTable._getHandle();
-  return handle.evaluate((cbaTableRow, cbaTable, data) => {
-    return new Promise((resolve) => {
+  return handle.evaluate((cbaTableRow, cbaTable, data) =>
+  {
+    return new Promise((resolve) =>
+    {
       cbaTable.addEventListener('dragndrop', ({detail}) =>
       {
         return resolve(detail);
@@ -189,13 +192,14 @@ async function triggerDrop(id, data)
       });
       cbaTableRow.dispatchEvent(event);
     });
-    
+
   }, table, data);
 }
 
 async function triggerDragStart(handle)
 {
-  return handle.evaluate((row) => {
+  return handle.evaluate((row) =>
+  {
     const event = new DragEvent("dragstart", {
       bubbles: true,
       dataTransfer: new DataTransfer()
@@ -214,7 +218,8 @@ async function itemIsRenderedOnRowIndex({texts}, index)
 async function isCbaTableRowHidden(id)
 {
   const handle = await cbaTable.getRowHandle(id);
-  return handle.evaluate((cbaTableRow) => {
+  return handle.evaluate((cbaTableRow) =>
+  {
     return window.getComputedStyle(cbaTableRow).getPropertyValue("display") === "none";
   });
 }

--- a/tests/smoke/cba-list-new/smoke.js
+++ b/tests/smoke/cba-list-new/smoke.js
@@ -28,7 +28,8 @@ const items = [
   },
 ];
 
-for (let i = 4; i < 20; i++) {
+for (let i = 4; i < 20; i++)
+{
   items.push({
     id: `row${i}`,
     data: `Info`,

--- a/tests/smoke/cba-list-new/smoke.js
+++ b/tests/smoke/cba-list-new/smoke.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 const cbaList = document.querySelector("cba-list-new");
 const items = [
   {
@@ -28,8 +29,7 @@ const items = [
   },
 ];
 
-for (let i = 4; i < 20; i++)
-{
+for (let i = 4; i < 20; i++) {
   items.push({
     id: `row${i}`,
     data: `Info`,

--- a/tests/smoke/cba-list/smoke.js
+++ b/tests/smoke/cba-list/smoke.js
@@ -28,7 +28,8 @@ const items = [
   },
 ];
 
-for (let i = 4; i < 20; i++) {
+for (let i = 4; i < 20; i++)
+{
   items.push({
     id: `row${i}`,
     data: `Info`,

--- a/tests/smoke/cba-table/smoke.js
+++ b/tests/smoke/cba-table/smoke.js
@@ -8,7 +8,8 @@ items.push({
   type: "Event"
 });
 
-for (let index = 0; index < 30; index++) {
+for (let index = 0; index < 30; index++)
+{
   items.push({
     id: "row" + index,
     data: "Info",

--- a/tests/smoke/cba-tabs/cba-tab-panel.css
+++ b/tests/smoke/cba-tabs/cba-tab-panel.css
@@ -1,4 +1,5 @@
-nav {
+nav
+{
   width: 200px;
 }
 

--- a/tests/smoke/cba-tabs/smoke.js
+++ b/tests/smoke/cba-tabs/smoke.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 document.addEventListener("DOMContentLoaded", () =>
 {
   document.querySelector("cba-tabs").select("import-tab");

--- a/tests/smoke/drag-drop/smoke.js
+++ b/tests/smoke/drag-drop/smoke.js
@@ -1,6 +1,9 @@
+/* eslint-disable no-console */
+
 const cbaTable = document.querySelector("cba-table");
 const items = [];
-for (let index = 0; index < 50; index++) {
+for (let index = 0; index < 50; index++)
+{
   items.push({
     id: "row" + index,
     data: "Info",
@@ -57,7 +60,8 @@ const listItems = [
   }
 ];
 
-for (let i = 3; i < 20; i++) {
+for (let i = 3; i < 20; i++)
+{
   listItems.push({
     id: `subrow${i}`,
     text: `List${i}`,

--- a/tests/smoke/res/highlight.css
+++ b/tests/smoke/res/highlight.css
@@ -4,7 +4,8 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 
 */
 
-.hljs {
+.hljs
+{
   display: block;
   overflow-x: auto;
   padding: 0.5em;
@@ -13,14 +14,16 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 }
 
 .hljs-comment,
-.hljs-quote {
+.hljs-quote
+{
   color: #998;
   font-style: italic;
 }
 
 .hljs-keyword,
 .hljs-selector-tag,
-.hljs-subst {
+.hljs-subst
+{
   color: #333;
   font-weight: bold;
 }
@@ -29,71 +32,85 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-literal,
 .hljs-variable,
 .hljs-template-variable,
-.hljs-tag .hljs-attr {
+.hljs-tag .hljs-attr
+{
   color: #008080;
 }
 
 .hljs-string,
-.hljs-doctag {
+.hljs-doctag
+{
   color: #d14;
 }
 
 .hljs-title,
 .hljs-section,
-.hljs-selector-id {
+.hljs-selector-id
+{
   color: #900;
   font-weight: bold;
 }
 
-.hljs-subst {
+.hljs-subst
+{
   font-weight: normal;
 }
 
 .hljs-type,
-.hljs-class .hljs-title {
+.hljs-class .hljs-title
+{
   color: #458;
   font-weight: bold;
 }
 
 .hljs-tag,
 .hljs-name,
-.hljs-attribute {
+.hljs-attribute
+{
   color: #000080;
   font-weight: normal;
 }
 
 .hljs-regexp,
-.hljs-link {
+.hljs-link
+{
   color: #009926;
 }
 
 .hljs-symbol,
-.hljs-bullet {
+.hljs-bullet
+{
   color: #990073;
 }
 
 .hljs-built_in,
-.hljs-builtin-name {
+.hljs-builtin-name
+{
   color: #0086b3;
 }
 
-.hljs-meta {
+.hljs-meta
+{
   color: #999;
   font-weight: bold;
 }
 
-.hljs-deletion {
+.hljs-deletion
+{
   background: #fdd;
 }
 
-.hljs-addition {
+.hljs-addition
+{
   background: #dfd;
 }
 
-.hljs-emphasis {
+.hljs-emphasis
+{
   font-style: italic;
 }
 
-.hljs-strong {
+.hljs-strong
+{
   font-weight: bold;
 }


### PR DESCRIPTION
What is included:
- Added eslint and config.
- Added stylelint and config.
  - Disabled [no-descending-specificity](https://stylelint.io/user-guide/rules/no-descending-specificity) rule for now to provide less overhead with addressing changes as part of current or https://github.com/browser-automation/cba-components/pull/53 PR.
- Fixed all automated fixes by `npm run test:eslint -- --fix` and `npm run test:stylelint -- --fix`, the rest - manually.
- disabled linting for `cba-list-new` to simplify https://github.com/browser-automation/cba-components/pull/53 refactoring.